### PR TITLE
Add solo scenarios for base game

### DIFF
--- a/VirtualGloomhavenBoard/Elm/src/Main.elm
+++ b/VirtualGloomhavenBoard/Elm/src/Main.elm
@@ -2870,7 +2870,7 @@ isValidScenario : String -> Bool
 isValidScenario scenarioId =
     case String.toInt scenarioId of
         Just i ->
-            i > 0 && i < 130
+            i > 0 && i < 133
 
         Nothing ->
             False

--- a/VirtualGloomhavenBoard/Elm/src/Main.elm
+++ b/VirtualGloomhavenBoard/Elm/src/Main.elm
@@ -2870,6 +2870,7 @@ isValidScenario : String -> Bool
 isValidScenario scenarioId =
     case String.toInt scenarioId of
         Just i ->
+            -- TODO: change end of range to 116 once Solo scenarios are moved to their final location
             i > 0 && i < 133
 
         Nothing ->

--- a/VirtualGloomhavenBoard/Elm/src/Main.elm
+++ b/VirtualGloomhavenBoard/Elm/src/Main.elm
@@ -2870,7 +2870,7 @@ isValidScenario : String -> Bool
 isValidScenario scenarioId =
     case String.toInt scenarioId of
         Just i ->
-            i > 0 && i < 120
+            i > 0 && i < 130
 
         Nothing ->
             False

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
@@ -49,8 +49,43 @@
                                         "mapTileData": {
                                             "ref": "a1b",
                                             "doors": [],
-                                            "overlays": [],
+                                            "overlays": [
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "cabinet"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [1, 1]
+                                                    ]
+                                                }
+                                            ],
                                             "monsters": [
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 2,
+                                                    "initialY": 1,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 2,
+                                                    "initialY": 2,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "vermling-shaman",
+                                                    "initialX": 0,
+                                                    "initialY": 1,
+                                                    "twoPlayer": "elite",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                }
                                             ],
                                             "turns": 3
                                         }

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
@@ -182,15 +182,6 @@
             },
             {
                 "ref": {
-                    "type": "starting-location"
-                },
-                "direction": "default",
-                "cells": [
-                    [0, 0]
-                ]
-            },
-            {
-                "ref": {
                     "type": "obstacle",
                     "subType": "cabinet"
                 },

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/116.json
@@ -1,0 +1,273 @@
+{
+    "id": 116,
+    "title": "Battle of the Bards",
+    "mapTileData": {
+        "ref": "b1a",
+        "doors": [
+            {
+                "subType": "wooden",
+                "direction": "default",
+                "room1X": 1,
+                "room1Y": -1,
+                "room2X": 2,
+                "room2Y": 5,
+                "mapTileData": {
+                    "ref": "i1a",
+                    "doors": [
+                        {
+                            "subType": "wooden",
+                            "direction": "default",
+                            "room1X": 0,
+                            "room1Y": -1,
+                            "room2X": 5,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "g2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 0
+                            }
+                        },
+                        {
+                            "subType": "wooden",
+                            "direction": "default",
+                            "room1X": 4,
+                            "room1Y": -1,
+                            "room2X": 1,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "g2b",
+                                "doors": [
+                                    {
+                                        "subType": "wooden",
+                                        "direction": "default",
+                                        "room1X": 3,
+                                        "room1Y": 3,
+                                        "room2X": 3,
+                                        "room2Y": 3,
+                                        "mapTileData": {
+                                            "ref": "a1b",
+                                            "doors": [],
+                                            "overlays": [],
+                                            "monsters": [
+                                            ],
+                                            "turns": 3
+                                        }
+                                    }
+                                ],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "barrel"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [1, 2]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "barrel"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [5, 1]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "stone-golem",
+                                        "initialX": 3,
+                                        "initialY": 1,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "table"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 4], [1, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "table"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, 3], [3, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "table"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 2], [1, 2]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "city-guard",
+                            "initialX": 2,
+                            "initialY": 3,
+                            "twoPlayer": "elite",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-archer",
+                            "initialX": 1,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-archer",
+                            "initialX": 2,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-archer",
+                            "initialX": 3,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-archer",
+                            "initialX": 4,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [0, 0]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "cabinet"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 1]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "bandit-archer",
+                "initialX": 0,
+                "initialY": 3,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-archer",
+                "initialX": 2,
+                "initialY": 3,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 1,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 2,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 3,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "city-guard",
+                "initialX": 2,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "city-guard",
+                "initialX": 1,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 3
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/117.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/117.json
@@ -1,0 +1,292 @@
+{
+    "id": 117,
+    "title": "Caravan escort",
+    "mapTileData": {
+        "ref": "l1b",
+        "doors": [
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 0,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 1,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 2,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 2,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 3,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 4,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 4,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 5,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 6,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 6,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 0,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [
+                    ],
+                    "monsters": [],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [-1, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [2, 3], [2, 4]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [-2, 5], [-2, 6]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-left-reverse",
+                "cells": [
+                    [-4, 2], [-5, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bookcase"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [-3, 1], [-4, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bookcase"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [2, 1], [1, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bookcase"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [2, 5], [1, 5]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bookcase"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [-3, 5], [-4, 5]
+                ]
+            }
+        ],
+        "monsters": [],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "city-guard",
+        "bandit-guard",
+        "bandit-archer",
+        "inox-guard",
+        "inox-archer",
+        "inox-shaman",
+        "vermling-scout",
+        "vermling-shaman",
+        "cave-bear"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/118.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/118.json
@@ -1,0 +1,410 @@
+{
+    "id": 118,
+    "title": "Caravan escort",
+    "mapTileData": {
+        "ref": "b1a",
+        "doors": [
+            {
+                "subType": "wooden",
+                "size": 1,
+                "direction": "default",
+                "room1X": 1,
+                "room1Y": -1,
+                "room2X": 2,
+                "room2Y": 5,
+                "mapTileData": {
+                    "ref": "i1a",
+                    "doors": [
+                        {
+                            "subType": "corridor",
+                            "material": "wood",
+                            "size": 1,
+                            "direction": "default",
+                            "room1X": 0,
+                            "room1Y": -1,
+                            "room2X": 3,
+                            "room2Y": 5,
+                            "mapTileData": {
+                                "ref": "i2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "material": "wood",
+                            "size": 1,
+                            "direction": "default",
+                            "room1X": 1,
+                            "room1Y": -1,
+                            "room2X": 3,
+                            "room2Y": 5,
+                            "mapTileData": {
+                                "ref": "i2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "material": "wood",
+                            "size": 1,
+                            "direction": "default",
+                            "room1X": 2,
+                            "room1Y": -1,
+                            "room2X": 3,
+                            "room2Y": 5,
+                            "mapTileData": {
+                                "ref": "i2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "material": "wood",
+                            "size": 1,
+                            "direction": "default",
+                            "room1X": 4,
+                            "room1Y": -1,
+                            "room2X": 3,
+                            "room2Y": 5,
+                            "mapTileData": {
+                                "ref": "i2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "material": "wood",
+                            "size": 1,
+                            "direction": "default",
+                            "room1X": 3,
+                            "room1Y": -1,
+                            "room2X": 3,
+                            "room2Y": 5,
+                            "mapTileData": {
+                                "ref": "i2b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "crate"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "crate"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, -6]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "barrel"
+                            },
+                            "direction": "horizontal",
+                            "cells": [
+                                [3, 0]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [0, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, -5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, -2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, -3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, -3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, -5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 0]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "cabinet"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [5, -2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "cabinet"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [0, -3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "horizontal",
+                            "cells": [
+                                [3, 3], [4, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "horizontal",
+                            "cells": [
+                                [1, 2], [2, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "horizontal",
+                            "cells": [
+                                [0, -5], [1, -5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "horizontal",
+                            "cells": [
+                                [3, -4], [4, -4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "shelf"
+                            },
+                            "direction": "diagonal-left",
+                            "cells": [
+                                [3, -1], [3, -2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "shelf"
+                            },
+                            "direction": "diagonal-left",
+                            "cells": [
+                                [1, 0], [0, -1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "treasure",
+                                "subType": "chest",
+                                "id": "Goal"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [0, -6]
+                            ]
+                        }
+                    ],
+                    "monsters": [],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [2, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [0, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "barrel"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [1, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "barrel"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [2, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "spike"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "spike"
+                },
+                "direction": "default",
+                "cells": [
+                    [0, 2]
+                ]
+            }
+        ],
+        "monsters": [],
+        "turns": 3
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "hound",
+        "bandit-guard",
+        "bandit-archer"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/118.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/118.json
@@ -1,6 +1,6 @@
 {
     "id": 118,
-    "title": "Caravan escort",
+    "title": "Storage Fees",
     "mapTileData": {
         "ref": "b1a",
         "doors": [

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/119.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/119.json
@@ -1,0 +1,326 @@
+{
+    "id": 119,
+    "title": "Return to the Black Barrow",
+    "mapTileData": {
+        "ref": "l1a",
+        "doors": [
+            {
+                "subType": "stone",
+                "direction": "vertical",
+                "room1X": -1,
+                "room1Y": 3,
+                "room2X": -1,
+                "room2Y": 1,
+                "mapTileData": {
+                    "ref": "g1b",
+                    "doors": [
+                        {
+                            "subType": "stone",
+                            "direction": "default",
+                            "room1X": 3,
+                            "room1Y": -1,
+                            "room2X": 2,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "i1b",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "table"
+                                        },
+                                        "direction": "horizontal",
+                                        "cells": [ [1, 1], [0, 1] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "table"
+                                        },
+                                        "direction": "horizontal",
+                                        "cells": [ [4, 1], [3, 1] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [0, 2] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [0, 3] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [0, 4] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [5, 2] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [4, 3] ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "coin",
+                                            "amount": 1
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [5, 4] ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "living-bones",
+                                        "initialX": 2,
+                                        "initialY": 0,
+                                        "twoPlayer": "none",
+                                        "threePlayer": "none",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "living-bones",
+                                        "initialX": 3,
+                                        "initialY": 0,
+                                        "twoPlayer": "none",
+                                        "threePlayer": "none",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "living-bones",
+                                        "initialX": 2,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "living-bones",
+                                        "initialX": 3,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "bandit-archer",
+                                        "initialX": 1,
+                                        "initialY": 4,
+                                        "twoPlayer": "none",
+                                        "threePlayer": "none",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "bandit-archer",
+                                        "initialX": 2,
+                                        "initialY": 4,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "bandit-archer",
+                                        "initialX": 3,
+                                        "initialY": 4,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "bandit-archer",
+                                        "initialX": 4,
+                                        "initialY": 4,
+                                        "twoPlayer": "none",
+                                        "threePlayer": "none",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [ [3, 0] ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [ [4, 0] ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "bandit-guard",
+                            "initialX": 2,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "none",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "bandit-guard",
+                            "initialX": 1,
+                            "initialY": 1,
+                            "twoPlayer": "none",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        },
+                        {
+                            "monster": "bandit-guard",
+                            "initialX": 2,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "none",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "bandit-archer",
+                            "initialX": 7,
+                            "initialY": 0,
+                            "twoPlayer": "none",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "bandit-archer",
+                            "initialX": 6,
+                            "initialY": 1,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        },
+                        {
+                            "monster": "bandit-archer",
+                            "initialX": 7,
+                            "initialY": 2,
+                            "twoPlayer": "none",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [4, 2] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [3, 3] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [4, 4] ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 0,
+                "twoPlayer": "none",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 1,
+                "twoPlayer": "none",
+                "threePlayer": "normal",
+                "fourPlayer": "elite"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 3,
+                "twoPlayer": "elite",
+                "threePlayer": "none",
+                "fourPlayer": "none"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 4,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 5,
+                "twoPlayer": "none",
+                "threePlayer": "normal",
+                "fourPlayer": "elite"
+            },
+            {
+                "monster": "bandit-guard",
+                "initialX": 0,
+                "initialY": 6,
+                "twoPlayer": "none",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/120.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/120.json
@@ -1,0 +1,147 @@
+{
+    "id": 120,
+    "title": "Stone Defense",
+    "mapTileData": {
+        "ref": "n1a",
+        "doors": [
+            {
+                "subType": "corridor",
+                "material": "natural-stone",
+                "size": 1,
+                "direction": "default",
+                "room1X": 5,
+                "room1Y": 7,
+                "room2X": 1,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "b4b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [5, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [6, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [5, 7] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "rock-column"
+                },
+                "direction": "default",
+                "cells": [
+                    [4, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "rock-column"
+                },
+                "direction": "default",
+                "cells": [
+                    [0, 5]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "rock-column"
+                },
+                "direction": "default",
+                "cells": [
+                    [6, 4]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "crystal"
+                },
+                "direction": "default",
+                "cells": [
+                    [5, 11]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "boulder-2"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [4, 4], [3, 5]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "boulder-2"
+                },
+                "direction": "diagonal-left",
+                "cells": [
+                    [0, 2], [0, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "rubble"
+                },
+                "direction": "default",
+                "cells": [
+                    [3, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "rubble"
+                },
+                "direction": "default",
+                "cells": [
+                    [5, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "rubble"
+                },
+                "direction": "default",
+                "cells": [
+                    [2, 6]
+                ]
+            }
+        ],
+        "monsters": [],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "sun-demon",
+        "ooze",
+        "cave-bear"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/121.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/121.json
@@ -1,0 +1,232 @@
+{
+    "id": 121,
+    "title": "An Unfortunate Intrusion",
+    "mapTileData": {
+        "ref": "n1b",
+        "doors": [
+            {
+                "subType": "corridor",
+                "material": "manmade-stone",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": -1,
+                "room2X": 6,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "g1b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 3
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "manmade-stone",
+                "size": 1,
+                "direction": "default",
+                "room1X": 3,
+                "room1Y": -1,
+                "room2X": 3,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "g1b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 3
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "manmade-stone",
+                "size": 1,
+                "direction": "default",
+                "room1X": 6,
+                "room1Y": -1,
+                "room2X": 0,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "g1b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [
+                        {
+                            "monster": "city-guard",
+                            "initialX": 3,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-guard",
+                            "initialX": 4,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 0,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 0,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 1,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 6,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 7,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-scout",
+                            "initialX": 6,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-shaman",
+                            "initialX": 0,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "vermling-shaman",
+                            "initialX": 7,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [5, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [4, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [3, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [2, 6] ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "spike"
+                },
+                "direction": "default",
+                "cells": [ [2, 0] ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "spike"
+                },
+                "direction": "default",
+                "cells": [ [5, 0] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "wall-section"
+                },
+                "direction": "default",
+                "cells": [
+                    [5, 2], [6, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "wall-section"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 2], [2, 2]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "city-guard",
+                "initialX": 1,
+                "initialY": 3,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "city-guard",
+                "initialX": 5,
+                "initialY": 3,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "sun-demon",
+        "ooze",
+        "cave-bear"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/121.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/121.json
@@ -224,9 +224,5 @@
         "turns": 0
     },
     "angle": 0,
-    "additionalMonsters": [
-        "sun-demon",
-        "ooze",
-        "cave-bear"
-    ]
+    "additionalMonsters": []
 }

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/122.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/122.json
@@ -1,0 +1,68 @@
+{
+    "id": 122,
+    "title": "Corrupted Laboratory",
+    "mapTileData": {
+        "ref": "g2b",
+        "doors": [
+            {
+                "subType": "wooden",
+                "direction": "vertical",
+                "room1X": 7,
+                "room1Y": 1,
+                "room2X": -1,
+                "room2Y": 1,
+                "mapTileData": {
+                    "ref": "i1b",
+                    "doors": [
+                        {
+                            "subType": "stone",
+                            "direction": "default",
+                            "room1X": 12,
+                            "room1Y": 4,
+                            "room2X": 11,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "a2a",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "wooden",
+                "direction": "default",
+                "room1X": 3,
+                "room1Y": 3,
+                "room2X": 3,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "a1b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [3,1] ]
+            }
+        ],
+        "monsters": [],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/122.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/122.json
@@ -17,21 +17,156 @@
                         {
                             "subType": "stone",
                             "direction": "default",
-                            "room1X": 12,
-                            "room1Y": 4,
-                            "room2X": 11,
-                            "room2Y": -1,
+                            "room1X": 4,
+                            "room1Y": 5,
+                            "room2X": 4,
+                            "room2Y": 0,
                             "mapTileData": {
                                 "ref": "a2a",
                                 "doors": [],
-                                "overlays": [],
-                                "monsters": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "treasure",
+                                            "subType": "chest",
+                                            "id": "Goal"
+                                        },
+                                        "direction": "default",
+                                        "cells": [ [0, 2] ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "black-imp",
+                                        "initialX": 0,
+                                        "initialY": 1,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
                                 "turns": 0
                             }
                         }
                     ],
-                    "overlays": [],
-                    "monsters": [],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 0]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [0, 1], [0, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [3, 0], [2, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [2, 2], [1, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "bookcase"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [3, 3], [3, 4]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "black-imp",
+                            "initialX": 0,
+                            "initialY": 3,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "black-imp",
+                            "initialX": 1,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "spitting-drake",
+                            "initialX": 5,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
                     "turns": 0
                 }
             },
@@ -46,7 +181,40 @@
                     "ref": "a1b",
                     "doors": [],
                     "overlays": [],
-                    "monsters": [],
+                    "monsters": [
+                        {
+                            "monster": "black-imp",
+                            "initialX": 3,
+                            "initialY": 1,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        },
+                        {
+                            "monster": "black-imp",
+                            "initialX": 0,
+                            "initialY": 2,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        },
+                        {
+                            "monster": "spitting-drake",
+                            "initialX": 0,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "spitting-drake",
+                            "initialX": 4,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
                     "turns": 0
                 }
             }
@@ -57,12 +225,113 @@
                     "type": "starting-location"
                 },
                 "direction": "default",
-                "cells": [ [3,1] ]
+                "cells": [ [0,0] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,1] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,2] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "barrel"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "barrel"
+                },
+                "direction": "default",
+                "cells": [
+                    [4, 0]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "crate"
+                },
+                "direction": "default",
+                "cells": [
+                    [6, 0]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "crate"
+                },
+                "direction": "default",
+                "cells": [
+                    [6, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "stairs"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [5, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "stairs"
+                },
+                "direction": "horizontal",
+                "cells": [
+                    [6, 1]
+                ]
             }
         ],
-        "monsters": [],
+        "monsters": [
+            {
+                "monster": "black-imp",
+                "initialX": 3,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "black-imp",
+                "initialX": 4,
+                "initialY": 1,
+                "twoPlayer": "elite",
+                "threePlayer": "elite",
+                "fourPlayer": "elite"
+            },
+            {
+                "monster": "spitting-drake",
+                "initialX": 4,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
         "turns": 0
     },
     "angle": 0,
-    "additionalMonsters": []
+    "additionalMonsters": [
+        "stone-golem"
+    ]
 }

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/123.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/123.json
@@ -232,11 +232,43 @@
                                             "monsters": [
                                                 {
                                                     "monster": "city-guard",
-                                                    "initialX": 1,
-                                                    "initialY": 1,
+                                                    "initialX": 0,
+                                                    "initialY": 0,
                                                     "twoPlayer": "normal",
                                                     "threePlayer": "normal",
                                                     "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 1,
+                                                    "initialY": 4,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 6,
+                                                    "initialY": 0,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 6,
+                                                    "initialY": 6,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 3,
+                                                    "initialY": 1,
+                                                    "twoPlayer": "elite",
+                                                    "threePlayer": "elite",
+                                                    "fourPlayer": "elite"
                                                 }
                                             ],
                                             "turns": 0
@@ -350,7 +382,5 @@
         "turns": 0
     },
     "angle": 0,
-    "additionalMonsters": [
-        "city-guard"
-    ]
+    "additionalMonsters": []
 }

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/123.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/123.json
@@ -1,0 +1,356 @@
+{
+    "id": 123,
+    "title": "Aftermath",
+    "mapTileData": {
+        "ref": "a1a",
+        "doors": [
+            {
+                "subType": "stone",
+                "direction": "default",
+                "room1X": 3,
+                "room1Y": 0,
+                "room2X": 1,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "g1b",
+                    "doors": [
+                        {
+                            "subType": "corridor",
+                            "direction": "default",
+                            "material": "manmade-stone",
+                            "size": 1,
+                            "room1X": 3,
+                            "room1Y": 3,
+                            "room2X": 3,
+                            "room2Y": 3,
+                            "mapTileData": {
+                                "ref": "a3b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 0
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "direction": "default",
+                            "material": "manmade-stone",
+                            "size": 1,
+                            "room1X": 4,
+                            "room1Y": 3,
+                            "room2X": 2,
+                            "room2Y": 3,
+                            "mapTileData": {
+                                "ref": "a3b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 0
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "direction": "default",
+                            "material": "manmade-stone",
+                            "size": 1,
+                            "room1X": 5,
+                            "room1Y": 3,
+                            "room2X": 1,
+                            "room2Y": 3,
+                            "mapTileData": {
+                                "ref": "a3b",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 0
+                            }
+                        },
+                        {
+                            "subType": "corridor",
+                            "direction": "default",
+                            "material": "manmade-stone",
+                            "size": 1,
+                            "room1X": 6,
+                            "room1Y": 3,
+                            "room2X": 0,
+                            "room2Y": 3,
+                            "mapTileData": {
+                                "ref": "a3b",
+                                "doors": [
+                                    {
+                                        "subType": "stone",
+                                        "direction": "default",
+                                        "room1X": 3,
+                                        "room1Y": 0,
+                                        "room2X": 1,
+                                        "room2Y": 7,
+                                        "mapTileData": {
+                                            "ref": "n1b",
+                                            "doors": [],
+                                            "overlays": [
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-2"
+                                                    },
+                                                    "direction": "diagonal-left",
+                                                    "cells": [
+                                                        [2, 0], [2, 1]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-3"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [6, 2], [7, 2], [6, 1]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-3"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [3, 6], [4, 6], [3, 5]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-3"
+                                                    },
+                                                    "direction": "diagonal-left",
+                                                    "cells": [
+                                                        [3, 2], [3, 3], [4, 2]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-1"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [4, 4]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-1"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [2, 5]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-1"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [5, 2]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-1"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [0, 3]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [1, 2]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [1, 3]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [4, 3]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [4, 1]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [5, 0]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "difficult-terrain",
+                                                        "subType": "rubble"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [6, 4]
+                                                    ]
+                                                }
+                                            ],
+                                            "monsters": [
+                                                {
+                                                    "monster": "city-guard",
+                                                    "initialX": 1,
+                                                    "initialY": 1,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                }
+                                            ],
+                                            "turns": 0
+                                        }
+                                    }
+                                ],
+                                "overlays": [],
+                                "monsters": [
+                                    {
+                                        "monster": "city-guard",
+                                        "initialX": 1,
+                                        "initialY": 1,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "city-guard",
+                                        "initialX": 0,
+                                        "initialY": 1,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "city-guard",
+                                        "initialX": 0,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-2"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [2, 2], [2, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-2"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [3, 1], [4, 0]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "city-guard",
+                            "initialX": 1,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-guard",
+                            "initialX": 5,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,2] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "boulder-2"
+                },
+                "direction": "diagonal-left",
+                "cells": [
+                    [1, 1], [2, 2]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "city-guard",
+                "initialX": 3,
+                "initialY": 1,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "city-guard"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/124.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/124.json
@@ -1,0 +1,172 @@
+{
+    "id": 124,
+    "title": "Elemental Secrets",
+    "mapTileData": {
+        "ref": "h1b",
+        "doors": [
+            {
+                "subType": "stone",
+                "direction": "vertical",
+                "room1X": 7,
+                "room1Y": 0,
+                "room2X": -1,
+                "room2Y": 1,
+                "mapTileData": {
+                    "ref": "b2b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [
+                        {
+                            "monster": "flame-demon",
+                            "initialX": 2,
+                            "initialY": 2,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "stone",
+                "direction": "vertical",
+                "room1X": 0,
+                "room1Y": 0,
+                "room2X": 3,
+                "room2Y": 1,
+                "mapTileData": {
+                    "ref": "b3b",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [
+                        {
+                            "monster": "wind-demon",
+                            "initialX": 1,
+                            "initialY": 2,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "stone",
+                "direction": "default",
+                "room1X": 3,
+                "room1Y": -1,
+                "room2X": 1,
+                "room2Y": 4,
+                "mapTileData": {
+                    "ref": "c2b",
+                    "doors": [],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "poison"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [0, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "poison"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 2]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "frost-demon",
+                            "initialX": 1,
+                            "initialY": 0,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        },
+                        {
+                            "monster": "earth-demon",
+                            "initialX": 2,
+                            "initialY": 0,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [3,6] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [4,6] ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "poison"
+                },
+                "direction": "default",
+                "cells": [
+                    [3, 1]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "earth-demon",
+                "initialX": 2,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "flame-demon",
+                "initialX": 0,
+                "initialY": 1,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "frost-demon",
+                "initialX": 5,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "wind-demon",
+                "initialX": 6,
+                "initialY": 1,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/125.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/125.json
@@ -1,0 +1,243 @@
+{
+    "id": 125,
+    "title": "Rodent Liberation",
+    "mapTileData": {
+        "ref": "e1a",
+        "doors": [
+            {
+                "subType": "stone",
+                "direction": "vertical",
+                "room1X": 5,
+                "room1Y": 2,
+                "room2X": 7,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "h1b",
+                    "doors": [
+                        {
+                            "subType": "stone",
+                            "direction": "default",
+                            "room1X": 3,
+                            "room1Y": 7,
+                            "room2X": 1,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "d1a",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "trap",
+                                            "subType": "spike"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [0, 1]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "trap",
+                                            "subType": "spike"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [3, 0]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "vermling-shaman",
+                                        "initialX": 1,
+                                        "initialY": 4,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "vermling-shaman",
+                                        "initialX": 4,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "vermling-scout",
+                                        "initialX": 1,
+                                        "initialY": 1,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }
+                                ],
+                                "turns": 3
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "water"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "water"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "water"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [4, 5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "water"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "water"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "altar"
+                            },
+                            "direction": "vertical",
+                            "cells": [
+                                [2, 0]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "altar"
+                            },
+                            "direction": "vertical",
+                            "cells": [
+                                [5, 0]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "altar"
+                            },
+                            "direction": "vertical",
+                            "cells": [
+                                [3, 3]
+                            ]
+                        }
+                    ],
+                    "monsters": [],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [1,2] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,1] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,3] ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "vermling-scout",
+                "initialX": 4,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "vermling-scout",
+                "initialX": 4,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "vermling-scout",
+                "initialX": 4,
+                "initialY": 4,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "vermling-scout",
+                "initialX": 3,
+                "initialY": 3,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "vermling-scout",
+                "initialX": 3,
+                "initialY": 1,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "vermling-scout",
+                "initialX": 3,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/126.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/126.json
@@ -1,0 +1,301 @@
+{
+    "id": 126,
+    "title": "Plane of Wild Beasts",
+    "mapTileData": {
+        "ref": "l1b",
+        "doors": [
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 0,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 1,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 2,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 2,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 3,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 4,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 4,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 5,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": -1,
+                "room1Y": 6,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 6,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [],
+                    "monsters": [],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "corridor",
+                "material": "earth",
+                "size": 1,
+                "direction": "default",
+                "room1X": 0,
+                "room1Y": 0,
+                "room2X": 5,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "l3a",
+                    "doors": [],
+                    "overlays": [
+                    ],
+                    "monsters": [],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [-1, 6]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [-2, 6]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [0, 6]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [
+                    [1, 6]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-left",
+                "cells": [
+                    [2, 0], [2, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [-3, 4], [-4, 5]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "tree-3"
+                },
+                "direction": "default",
+                "cells": [
+                    [2, 4], [3, 4], [2, 3]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "tree-3"
+                },
+                "direction": "diagonal-left",
+                "cells": [ [-3, 1], [-2, 2], [-2, 1] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bush"
+                },
+                "direction": "default",
+                "cells": [
+                    [-4, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bush"
+                },
+                "direction": "default",
+                "cells": [
+                    [-2, 5]
+                ]
+            }
+        ],
+        "monsters": [],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": [
+        "hound",
+        "spitting-drake",
+        "cave-bear"
+    ]
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/127.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/127.json
@@ -1,0 +1,233 @@
+{
+    "id": 127,
+    "title": "Armory Heist",
+    "mapTileData": {
+        "ref": "e1a",
+        "doors": [
+            {
+                "subType": "stone",
+                "direction": "vertical",
+                "room1X": 5,
+                "room1Y": 2,
+                "room2X": 7,
+                "room2Y": 0,
+                "mapTileData": {
+                    "ref": "h1b",
+                    "doors": [
+                        {
+                            "subType": "stone",
+                            "direction": "default",
+                            "room1X": 3,
+                            "room1Y": 7,
+                            "room2X": 3,
+                            "room2Y": 3,
+                            "mapTileData": {
+                                "ref": "a2a",
+                                "doors": [
+                                    {
+                                        "subType": "stone",
+                                        "direction": "default",
+                                        "room1X": -1,
+                                        "room1Y": 1,
+                                        "room2X": -1,
+                                        "room2Y": 1,
+                                        "mapTileData": {
+                                            "ref": "b2b",
+                                            "doors": [],
+                                            "overlays": [
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "pillar"
+                                                    },
+                                                    "direction": "vertical",
+                                                    "cells": [
+                                                        [1, 1]
+                                                    ]
+                                                },
+                                                {
+                                                    "ref": {
+                                                        "type": "treasure",
+                                                        "subType": "chest",
+                                                        "id": "Goal"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [2, 3]
+                                                    ]
+                                                }
+                                            ],
+                                            "monsters": [
+                                                {
+                                                    "monster": "ancient-artillery",
+                                                    "initialX": 0,
+                                                    "initialY": 3,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "ancient-artillery",
+                                                    "initialX": 3,
+                                                    "initialY": 0,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                }
+                                            ],
+                                            "turns": 3
+                                        }
+                                    }
+                                ],
+                                "overlays": [
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "stone-golem",
+                                        "initialX": 3,
+                                        "initialY": 1,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "city-guard",
+                                        "initialX": 0,
+                                        "initialY": 2,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "pillar"
+                            },
+                            "direction": "vertical",
+                            "cells": [
+                                [3, 3]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "pillar"
+                            },
+                            "direction": "vertical",
+                            "cells": [
+                                [3, 5]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [5, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "bear"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 1]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "city-guard",
+                            "initialX": 4,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "city-guard",
+                            "initialX": 0,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "stone-golem",
+                            "initialX": 3,
+                            "initialY": 6,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [1,2] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,1] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,3] ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "city-guard",
+                "initialX": 4,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "city-guard",
+                "initialX": 4,
+                "initialY": 4,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/128.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/128.json
@@ -1,0 +1,288 @@
+{
+    "id": 128,
+    "title": "Harvesting the Night",
+    "mapTileData": {
+        "ref": "g2a",
+        "doors": [
+            {
+                "subType": "dark-fog",
+                "direction": "vertical",
+                "room1X": 7,
+                "room1Y": 1,
+                "room2X": -1,
+                "room2Y": 3,
+                "mapTileData": {
+                    "ref": "l2a",
+                    "doors": [
+                        {
+                            "subType": "dark-fog",
+                            "direction": "vertical",
+                            "room1X": 4,
+                            "room1Y": 3,
+                            "room2X": -1,
+                            "room2Y": 1,
+                            "mapTileData": {
+                                "ref": "b4b",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "rock-column"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [2, 2]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "night-demon",
+                                        "initialX": 2,
+                                        "initialY": 1,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "dark-fog",
+                            "direction": "vertical",
+                            "room1X": 3,
+                            "room1Y": -1,
+                            "room2X": 2,
+                            "room2Y": 0,
+                            "mapTileData": {
+                                "ref": "a2b",
+                                "doors": [],
+                                "overlays": [
+
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "nest"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [1, 2]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "night-demon",
+                                        "initialX": 0,
+                                        "initialY": 2,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    },
+                                    {
+                                        "monster": "night-demon",
+                                        "initialX": 1,
+                                        "initialY": 1,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "night-demon",
+                                        "initialX": 2,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "dark-pit"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [2, 5], [3, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "rock-column"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 2]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "night-demon",
+                            "initialX": 2,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "night-demon",
+                            "initialX": 2,
+                            "initialY": 4,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "deep-terror",
+                            "initialX": 4,
+                            "initialY": 6,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "deep-terror",
+                            "initialX": 4,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            },
+            {
+                "subType": "dark-fog",
+                "direction": "vertical",
+                "room1X": 3,
+                "room1Y": -1,
+                "room2X": 2,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "d2b",
+                    "doors": [],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "rock-column"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [0, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "nest"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 3]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "night-demon",
+                            "initialX": 0,
+                            "initialY": 3,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "night-demon",
+                            "initialX": 2,
+                            "initialY": 1,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "deep-terror",
+                            "initialX": 1,
+                            "initialY": 4,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,0] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,1] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,2] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "dark-pit"
+                },
+                "direction": "diagonal-left",
+                "cells": [
+                    [3, 1], [3, 0]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "night-demon",
+                "initialX": 4,
+                "initialY": 1,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "deep-terror",
+                "initialX": 7,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "deep-terror",
+                "initialX": 7,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 3
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/129.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/129.json
@@ -1,0 +1,340 @@
+{
+    "id": 129,
+    "title": "The Caged Bear",
+    "mapTileData": {
+        "ref": "d2b",
+        "doors": [
+            {
+                "subType": "dark-fog",
+                "direction": "vertical",
+                "room1X": 1,
+                "room1Y": -1,
+                "room2X": 6,
+                "room2Y": 3,
+                "mapTileData": {
+                    "ref": "g2a",
+                    "doors": [
+                        {
+                            "subType": "dark-fog",
+                            "direction": "vertical",
+                            "room1X": 1,
+                            "room1Y": -1,
+                            "room2X": 5,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "n1a",
+                                "doors": [],
+                                "overlays": [],
+                                "monsters": [],
+                                "turns": 3
+                            }
+                        },
+                        {
+                            "subType": "dark-fog",
+                            "direction": "vertical",
+                            "room1X": 5,
+                            "room1Y": -1,
+                            "room2X": 1,
+                            "room2Y": -1,
+                            "mapTileData": {
+                                "ref": "n1a",
+                                "doors": [
+                                    {
+                                        "subType": "dark-fog",
+                                        "direction": "vertical",
+                                        "room1X": 3,
+                                        "room1Y": 7,
+                                        "room2X": 3,
+                                        "room2Y": -1,
+                                        "mapTileData": {
+                                            "ref": "e1b",
+                                            "doors": [],
+                                            "overlays": [],
+                                            "monsters": [],
+                                            "turns": 3
+                                        }
+                                    },
+                                    {
+                                        "subType": "dark-fog",
+                                        "direction": "vertical",
+                                        "room1X": 1,
+                                        "room1Y": 7,
+                                        "room2X": 1,
+                                        "room2Y": -1,
+                                        "mapTileData": {
+                                            "ref": "e1b",
+                                            "doors": [],
+                                            "overlays": [
+                                                {
+                                                    "ref": {
+                                                        "type": "obstacle",
+                                                        "subType": "boulder-1"
+                                                    },
+                                                    "direction": "default",
+                                                    "cells": [
+                                                        [2, 1]
+                                                    ]
+                                                }
+                                            ],
+                                            "monsters": [
+                                                {
+                                                    "monster": "cave-bear",
+                                                    "initialX": 2,
+                                                    "initialY": 3,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                },
+                                                {
+                                                    "monster": "vermling-shaman",
+                                                    "initialX": 2,
+                                                    "initialY": 4,
+                                                    "twoPlayer": "normal",
+                                                    "threePlayer": "normal",
+                                                    "fourPlayer": "normal"
+                                                }
+                                            ],
+                                            "turns": 3
+                                        }
+                                    }
+                                ],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-3"
+                                        },
+                                        "direction": "diagonal-right",
+                                        "cells": [
+                                            [3, 1], [4, 0], [3, 0]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-2"
+                                        },
+                                        "direction": "diagonal-left",
+                                        "cells": [
+                                            [3, 3], [3, 2]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-1"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [4, 3]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-1"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [6, 5]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-1"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [1, 2]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-3"
+                                        },
+                                        "direction": "diagonal-left",
+                                        "cells": [
+                                            [3, 5], [3, 4], [2, 5]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "boulder-2"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [3, 6], [2, 6]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "hound",
+                                        "initialX": 7,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "hound",
+                                        "initialX": 5,
+                                        "initialY": 6,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "forest-imp",
+                                        "initialX": 1,
+                                        "initialY": 4,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }
+                                ],
+                                "turns": 3
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-1"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-2"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 2], [4, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-2"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [4, 0], [3, 1]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "rending-drake",
+                            "initialX": 3,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "rending-drake",
+                            "initialX": 5,
+                            "initialY": 0,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 0
+                }
+            },
+            {
+                "subType": "dark-fog",
+                "direction": "vertical",
+                "room1X": -5,
+                "room1Y": -1,
+                "room2X": 2,
+                "room2Y": 4,
+                "mapTileData": {
+                    "ref": "b4b",
+                    "doors": [],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "starting-location"
+                            },
+                            "direction": "default",
+                            "cells": [ [0,1] ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "boulder-1"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [1, 2]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "forest-imp",
+                            "initialX": 0,
+                            "initialY": 3,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "forest-imp",
+                            "initialX": 2,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        }
+                    ],
+                    "turns": 3
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,3] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "boulder-3"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [0, 1], [0, 2], [1, 2]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "hound",
+                "initialX": 3,
+                "initialY": 0,
+                "twoPlayer": "elite",
+                "threePlayer": "elite",
+                "fourPlayer": "elite"
+            }
+        ],
+        "turns": 0
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/130.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/130.json
@@ -1,0 +1,236 @@
+{
+    "id": 130,
+    "title": "Corrupted Hunt",
+    "mapTileData": {
+        "ref": "d1b",
+        "doors": [
+            {
+                "subType": "light-fog",
+                "direction": "vertical",
+                "room1X": 1,
+                "room1Y": 5,
+                "room2X": 3,
+                "room2Y": 1,
+                "mapTileData": {
+                    "ref": "c2a",
+                    "doors": [],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "log"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [2, 2], [2, 3]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "earth-demon",
+                            "initialX": 1,
+                            "initialY": 2,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 1
+                }
+            },
+            {
+                "subType": "light-fog",
+                "direction": "vertical",
+                "room1X": 4,
+                "room1Y": 1,
+                "room2X": 5,
+                "room2Y": -1,
+                "mapTileData": {
+                    "ref": "g1a",
+                    "doors": [
+                        {
+                            "subType": "light-fog",
+                            "direction": "vertical",
+                            "room1X": 7,
+                            "room1Y": 1,
+                            "room2X": -1,
+                            "room2Y": 1,
+                            "mapTileData": {
+                                "ref": "a4a",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "nest"
+                                        },
+                                        "direction": "diagonal-right",
+                                        "cells": [
+                                            [2, 2]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "giant-viper",
+                                        "initialX": 1,
+                                        "initialY": 1,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    },
+                                    {
+                                        "monster": "giant-viper",
+                                        "initialX": 2,
+                                        "initialY": 1,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    },
+                                    {
+                                        "monster": "giant-viper",
+                                        "initialX": 1,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "giant-viper",
+                                        "initialX": 3,
+                                        "initialY": 2,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 0
+                            }
+                        },
+                        {
+                            "subType": "light-fog",
+                            "direction": "vertical",
+                            "room1X": -1,
+                            "room1Y": 1,
+                            "room2X": -1,
+                            "room2Y": 1,
+                            "mapTileData": {
+                                "ref": "f1b",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "nest"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [1, 8]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "tree-3"
+                                        },
+                                        "direction": "diagonal-left",
+                                        "cells": [
+                                            [2, 4], [1, 3], [1, 4]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "spitting-drake",
+                                        "initialX": 1,
+                                        "initialY": 7,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }
+                                ],
+                                "turns": 3
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "stump"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "stump"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [5, 0]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "flame-demon",
+                            "initialX": 0,
+                            "initialY": 1,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [0,2] ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "tree-3"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [1, 3], [2, 3], [2, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-left",
+                "cells": [
+                    [1, 1], [2, 0]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "hound",
+                "initialX": 4,
+                "initialY": 2,
+                "twoPlayer": "elite",
+                "threePlayer": "elite",
+                "fourPlayer": "elite"
+            }
+        ],
+        "turns": 2
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}

--- a/VirtualGloomhavenBoard/wwwroot/data/scenarios/131.json
+++ b/VirtualGloomhavenBoard/wwwroot/data/scenarios/131.json
@@ -1,0 +1,325 @@
+{
+    "id": 131,
+    "title": "Unnatural Insults",
+    "mapTileData": {
+        "ref": "g1a",
+        "doors": [
+            {
+                "subType": "light-fog",
+                "direction": "vertical",
+                "room1X": -1,
+                "room1Y": 1,
+                "room2X": -1,
+                "room2Y": 3,
+                "mapTileData": {
+                    "ref": "m1b",
+                    "doors": [
+                        {
+                            "subType": "light-fog",
+                            "direction": "vertical",
+                            "room1X": 5,
+                            "room1Y": 6,
+                            "room2X": 2,
+                            "room2Y": 4,
+                            "mapTileData": {
+                                "ref": "c2a",
+                                "doors": [
+                                    {
+                                        "subType": "corridor",
+                                        "material": "earth",
+                                        "direction": "vertical",
+                                        "size": 1,
+                                        "room1X": 3,
+                                        "room1Y": 3,
+                                        "room2X": 1,
+                                        "room2Y": -1,
+                                        "mapTileData": {
+                                            "ref": "d1b",
+                                            "doors": [],
+                                            "overlays": [],
+                                            "monsters": [],
+                                            "turns": 1
+                                        }
+                                    }
+                                ],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "stump"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [2, 2]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "cultist",
+                                        "initialX": 1,
+                                        "initialY": 0,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "living-bones",
+                                        "initialX": 1,
+                                        "initialY": 3,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    }
+                                ],
+                                "turns": 2
+                            }
+                        },
+                        {
+                            "subType": "light-fog",
+                            "direction": "vertical",
+                            "room1X": 3,
+                            "room1Y": 7,
+                            "room2X": 0,
+                            "room2Y": 0,
+                            "mapTileData": {
+                                "ref": "d1b",
+                                "doors": [],
+                                "overlays": [
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "bush"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [2, 3]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "obstacle",
+                                            "subType": "bush"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [3, 0]
+                                        ]
+                                    },
+                                    {
+                                        "ref": {
+                                            "type": "trap",
+                                            "subType": "spike"
+                                        },
+                                        "direction": "default",
+                                        "cells": [
+                                            [0, 1]
+                                        ]
+                                    }
+                                ],
+                                "monsters": [
+                                    {
+                                        "monster": "living-corpse",
+                                        "initialX": 1,
+                                        "initialY": 0,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "living-corpse",
+                                        "initialX": 1,
+                                        "initialY": 3,
+                                        "twoPlayer": "normal",
+                                        "threePlayer": "normal",
+                                        "fourPlayer": "normal"
+                                    },
+                                    {
+                                        "monster": "inox-shaman",
+                                        "initialX": 4,
+                                        "initialY": 2,
+                                        "twoPlayer": "elite",
+                                        "threePlayer": "elite",
+                                        "fourPlayer": "elite"
+                                    }
+                                ],
+                                "turns": 1
+                            }
+                        }
+                    ],
+                    "overlays": [
+                        {
+                            "ref": {
+                                "type": "difficult-terrain",
+                                "subType": "log"
+                            },
+                            "direction": "diagonal-left",
+                            "cells": [
+                                [3, 3], [4, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "tree-3"
+                            },
+                            "direction": "diagonal-left",
+                            "cells": [
+                                [1, 4], [1, 5], [2, 4]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "obstacle",
+                                "subType": "tree-3"
+                            },
+                            "direction": "diagonal-right",
+                            "cells": [
+                                [3, 0], [2, 1], [3, 1]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [2, 2]
+                            ]
+                        },
+                        {
+                            "ref": {
+                                "type": "trap",
+                                "subType": "spike"
+                            },
+                            "direction": "default",
+                            "cells": [
+                                [3, 5]
+                            ]
+                        }
+                    ],
+                    "monsters": [
+                        {
+                            "monster": "living-bones",
+                            "initialX": 1,
+                            "initialY": 2,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "living-bones",
+                            "initialX": 2,
+                            "initialY": 6,
+                            "twoPlayer": "normal",
+                            "threePlayer": "normal",
+                            "fourPlayer": "normal"
+                        },
+                        {
+                            "monster": "cultist",
+                            "initialX": 4,
+                            "initialY": 1,
+                            "twoPlayer": "elite",
+                            "threePlayer": "elite",
+                            "fourPlayer": "elite"
+                        }
+                    ],
+                    "turns": 0
+                }
+            }
+        ],
+        "overlays": [
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [7,0] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [6,1] ]
+            },
+            {
+                "ref": {
+                    "type": "starting-location"
+                },
+                "direction": "default",
+                "cells": [ [7,2] ]
+            },
+            {
+                "ref": {
+                    "type": "difficult-terrain",
+                    "subType": "log"
+                },
+                "direction": "diagonal-right",
+                "cells": [
+                    [3, 2], [3, 1]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "stump"
+                },
+                "direction": "default",
+                "cells": [
+                    [2, 0]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "obstacle",
+                    "subType": "bush"
+                },
+                "direction": "default",
+                "cells": [
+                    [6, 2]
+                ]
+            },
+            {
+                "ref": {
+                    "type": "trap",
+                    "subType": "spike"
+                },
+                "direction": "default",
+                "cells": [
+                    [4, 1]
+                ]
+            }
+        ],
+        "monsters": [
+            {
+                "monster": "living-corpse",
+                "initialX": 2,
+                "initialY": 1,
+                "twoPlayer": "elite",
+                "threePlayer": "elite",
+                "fourPlayer": "elite"
+            },
+            {
+                "monster": "living-corpse",
+                "initialX": 1,
+                "initialY": 0,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            },
+            {
+                "monster": "living-corpse",
+                "initialX": 0,
+                "initialY": 2,
+                "twoPlayer": "normal",
+                "threePlayer": "normal",
+                "fourPlayer": "normal"
+            }
+        ],
+        "turns": 3
+    },
+    "angle": 0,
+    "additionalMonsters": []
+}


### PR DESCRIPTION
Created JSON files for all solo scenarios for base game (except Cthulhu), using ids 116-131. These should be changed and ordered once we can move them to their final place.
(Note that this PR does not include the diviner solo scenario.)
I also changed the valid range of scenario numbers, so the added ones could be selected. That should be changed to 1-115 once the scenarios are moved.